### PR TITLE
Add `{--locked,}` to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
           - 1.43.0
           - stable
           - beta
+        cargo-locked: ["--locked", ""]
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -28,10 +29,15 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
+      - name: Update `Cargo.lock`
+        if: ${{ matrix.cargo-locked }} != "--locked"
+        run: cargo update
+
       - name: Cargo check
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: ${{ matrix.cargo-locked }}
 
   # == BUILD & TEST == #
   build-and-test:

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -24,6 +24,7 @@ jobs:
           - stable
           - beta
           - nightly
+        cargo-locked: ["--locked", ""]
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -35,10 +36,14 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
+      - name: Update `Cargo.lock`
+        if: ${{ matrix.cargo-locked }} != "--locked"
+        run: cargo update
+
       - name: Cargo test
         uses: actions-rs/cargo@v1
         env:
           RUSTC_BOOTSTRAP: "1"
         with:
           command: test
-          args: --features nightly
+          args: ${{ matrix.cargo-locked }} --features nightly


### PR DESCRIPTION
This is to make sure the crate is honest _w.r.t._ its usage of the minimal versions of its dependencies. It also tries to run the highest possible semver dependency so as to make sure the dependencies don't include incorrect semver breakage.