### PR TITLE
Use `doc = include_str!` instead of `doc(include`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,7 @@ jobs:
         rust-toolchains:
           - 1.43.0
           - stable
+          - nightly
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -65,10 +66,15 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: Cargo test
+      - name: Cargo test (nightly)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
-        env:
-          RUSTC_BOOTSTRAP: "1"
         with:
           command: test
           args: --features nightly
+
+      - name: Cargo test
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -40,10 +40,16 @@ jobs:
         if: matrix.cargo-locked != '--locked'
         run: cargo update
 
-      - name: Cargo test
+      - name: Cargo test (nightly)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
-        env:
-          RUSTC_BOOTSTRAP: "1"
         with:
           command: test
           args: ${{ matrix.cargo-locked }} --features nightly
+
+      - name: Cargo test
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.cargo-locked }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![forbid(unsafe_code)]
 #![allow(nonstandard_style, unused_imports)]
 #![cfg_attr(feature = "nightly",
-    feature(external_doc),
-    doc(include = "../README.md"),
+    cfg_attr(all(), doc = include_str!("../README.md")),
 )]
 
 extern crate proc_macro;


### PR DESCRIPTION
This fixes CI breakage on nightly due to the latter having been removed.